### PR TITLE
Publish secure to di

### DIFF
--- a/pipeline-common/publish_data/common_utils/args_utils.py
+++ b/pipeline-common/publish_data/common_utils/args_utils.py
@@ -7,6 +7,9 @@ def parse_arguments():
         "-t", "--test", action="store_true", help="This argument enables the test service of DevOps Intelligence."
     )
     parser.add_argument(
+        "-s", "--secure", action="store_true", help="This argument enables the secure service of DevOps Intelligence."
+    )
+    parser.add_argument(
         "-b", "--build", action="store_true", help="This argument enables the test service of DevOps Intelligence.."
     )
     parser.add_argument(

--- a/pipeline-common/publish_data/common_utils/constants.py
+++ b/pipeline-common/publish_data/common_utils/constants.py
@@ -65,6 +65,24 @@ class DeploymentTemplate:
         self.serviceoverride = True
         self.status = None
 
+class ImageScanTemplate:
+    def __init__(self):
+        self.vulnerable_image_scan = []
+        self.serviceoverride = None
+        self.servicename = None
+
+class VulnerabilityTemplate:
+    def __init__(self,cvss,description,image_digest,pack_name,pack_path,pack_version,severity,url,id):
+        self.cvss_score = cvss
+        self.description = description
+        self.image_digest = image_digest
+        self.package_name = pack_name
+        self.package_path = pack_path
+        self.package_version = pack_version
+        self.severity = severity
+        self.url_datasource = url
+        self.vulnerability_id = id
+
 
 TOKEN_NAME = os.getenv("TOKEN_NAME", "tokenapp")
 BROKER = "mcmp:devops-intelligence:service"
@@ -84,6 +102,9 @@ UTC_FORMAT = "%FT%TZ"
 BUILD_TOKEN = os.getenv("BUILD_TOKEN", "")
 TEST_TOKEN = os.getenv("TEST_TOKEN", "")
 DEPLOY_TOKEN = os.getenv("DEPLOY_TOKEN", "")
+SECURE_TOKEN = os.getenv("SECURE_TOKEN","")
+
+VULNERABILITIES_URL_TEMPLATE = "{0}/dash/api/dev_secops/v1/services/{1}/image-scan?scannedBy={2}&scannedTime={3}"
 
 """
 {0} tenant url (not api url)

--- a/pipeline-common/publish_data/load_data/devops_secure/secure.py
+++ b/pipeline-common/publish_data/load_data/devops_secure/secure.py
@@ -14,7 +14,7 @@ LOGGER = loggers.create_logger_module("devops-intelligence-publisher")
 
 TOKEN_API = "dash/api/dev_secops/v1/config/tokens"
 SCANNED_BY = "snyk"
-LIMIT_PER_REQUEST = 20
+LIMIT_PER_REQUEST = 100
 
 def __chunks(lst, n):
     for i in range(0, len(lst), n):
@@ -115,5 +115,3 @@ def post_vulnerabilities_scans( tenant_url, bearer_token ):
         traceback.print_exc()
         LOGGER.error(str(e))
         return False, str(e)
-
-    return True, None

--- a/pipeline-common/publish_data/load_data/devops_secure/secure.py
+++ b/pipeline-common/publish_data/load_data/devops_secure/secure.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timedelta
+import json
+from random import randint, choice
+import uuid
+import requests
+import os
+import traceback
+import uuid
+
+from common_utils.constants import SECURE_TOKEN, loggers, SERVICE_NAME, VULNERABILITIES_URL_TEMPLATE, ImageScanTemplate, VulnerabilityTemplate
+from load_data.tokens import tokens
+
+LOGGER = loggers.create_logger_module("devops-intelligence-publisher")
+
+TOKEN_API = "dash/api/dev_secops/v1/config/tokens"
+SCANNED_BY = "snyk"
+LIMIT_PER_REQUEST = 20
+
+def __chunks(lst, n):
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+
+def __publish_image_scans(service_name,raw_json,tenant_url,secure_token):
+    try:
+
+        scan = ImageScanTemplate()
+        scan.servicename = service_name
+        scan.serviceoverride = True
+
+        if not isinstance(raw_json, list):
+            raw_json = [raw_json]
+
+        vulnerabilities = []
+        used = {}
+
+        for report in raw_json:
+            
+            if "vulnerabilities" not in report: raise Exception(f"Missing attribute vulnerabilities from raw data. Service {service_name}")
+
+            for vul_data in report["vulnerabilities"]:
+
+                if vul_data["id"] not in used:
+
+                    used[vul_data["id"]] = vul_data["id"]
+
+                    vulnerabilities.append( VulnerabilityTemplate(
+                        cvss=vul_data["cvssScore"],
+                        description=vul_data["description"],
+                        image_digest=vul_data["from"][0] if len(vul_data["from"]) > 0 else "",
+                        pack_name=vul_data["packageName"],
+                        pack_version=vul_data["version"],
+                        pack_path=vul_data["name"],
+                        severity=vul_data["severity"],
+                        url=vul_data["references"][0]["url"] if len(vul_data["references"]) > 0 else "",
+                        id=vul_data["id"]
+                    ).__dict__)
+
+        chunk_counter = 1
+
+        for chunck in __chunks(vulnerabilities,LIMIT_PER_REQUEST):
+
+            scan.servicename = f"{scan.servicename}-{chunk_counter}"
+
+            chunk_counter +=1
+
+            scan.vulnerable_image_scan = chunck
+
+            date = (datetime.utcnow() - timedelta(days=0)).isoformat("T")+"Z"
+            
+            ENDPOINT = VULNERABILITIES_URL_TEMPLATE.format( tenant_url, scan.servicename, SCANNED_BY, date )
+            
+            payload = scan.__dict__
+
+            headers = { 'Authorization': 'TOKEN ' + secure_token, 'Content-Type': 'application/json', 'accept': 'application/json' }
+
+            response = requests.post( data=json.dumps(payload), url= ENDPOINT, headers=headers )
+            
+            LOGGER.info( "Code = " + str(response.status_code))
+
+            if response.status_code != 200 and response.status_code != 201:
+                LOGGER.error( "Error = " +  str(response.text))
+                return False, str(response.text)
+
+        return True, ""
+    except Exception as e:
+        return False, str(e)
+    
+
+def post_vulnerabilities_scans( tenant_url, bearer_token ):
+    try:
+
+        DEVOPS_SECURE_TOKEN = (
+            SECURE_TOKEN if SECURE_TOKEN != "" else tokens.get_token("SECURE", tenant_url, bearer_token, TOKEN_API).token
+        )
+
+        DB_JSON_REPORT_PATH = os.getenv("DB_JSON_REPORT_PATH",False)
+        WEB_JSON_REPORT_PATH = os.getenv("WEB_JSON_REPORT_PATH",False)
+
+        if not DB_JSON_REPORT_PATH: raise Exception("DB_JSON_REPORT_PATH value is missing")
+        if not WEB_JSON_REPORT_PATH: raise Exception("WEB_JSON_REPORT_PATH value is missing")
+
+        db_json_file = open(DB_JSON_REPORT_PATH,"r")
+        web_json_file = open(WEB_JSON_REPORT_PATH,"r")
+
+        db_report = json.load(db_json_file)
+        web_report = json.load(web_json_file)
+
+        db_result, db_err = __publish_image_scans(f"petstore_db_service",db_report,tenant_url,DEVOPS_SECURE_TOKEN)
+        web_result, web_err = __publish_image_scans(f"petstore_web_service",web_report,tenant_url,DEVOPS_SECURE_TOKEN)
+
+        return db_result and web_result, f"{db_err}{web_err}"
+
+    except Exception as e:
+        traceback.print_exc()
+        LOGGER.error(str(e))
+        return False, str(e)
+
+    return True, None

--- a/pipeline-common/publish_data/publish.py
+++ b/pipeline-common/publish_data/publish.py
@@ -1,6 +1,7 @@
 from load_data.devops_builds.builds import post_build_data
 from load_data.devops_tests.tests import post_tests_data
 from load_data.devops_deployments.deployments import post_deployment_data
+from load_data.devops_secure.secure import post_vulnerabilities_scans
 from common_utils import args_utils, loggers
 
 import os, sys
@@ -36,6 +37,13 @@ def main():
         result, err = post_deployment_data(TENANT_URL, BEARER_TOKEN)
         if not result:
             LOGGER.error("Error = Data couldn't be published.")
+            return
+        LOGGER.info("The data was published successfully.")
+    if ARGS.secure:
+        LOGGER.info(INFO_MESSAGE.format("Secure"))
+        result, err = post_vulnerabilities_scans(TENANT_URL, BEARER_TOKEN)
+        if not result:
+            LOGGER.error(f"Error = Data couldn't be published")
             return
         LOGGER.info("The data was published successfully.")
     # if check_flags > 1:


### PR DESCRIPTION
The PR includes thew new flow to post vulnerability scans to DevOps Intelligence. This is included in the pipeline-common/publish_data folder.

To run it yo will need to call the publish.py file with the `--secure` flag. Please consider:

Instead of displaying the `docker scans` results on the logs, you will need to output the scans as a json file as follows:

`docker scan $IMAGE_NAME --json >>  sample_output.json`

Once done and before invoking the python script, export the following env vars:

`SECURE_TOKEN`: secure token generated from DI
`DB_JSON_REPORT_PATH`: path to the json file that resulted from the docker scan of the db image
`WEB_JSON_REPORT_PATH`: path to the json file that resulted from the docker scan of the web app image
